### PR TITLE
add profile for heroku

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,1 @@
+echo ${GOOGLE_CREDENTIALS} > /app/google-credentials.json


### PR DESCRIPTION
## What

heroku起動時に読み込ませるための `.profile`ファイルを追加。
GCP周りの設定ファイルを出力するようにする。
ただ、環境変数をheroku上で設定しておけばよさそうであれば、当該ファイルは削除する