### PR TITLE
Google Driveに上げた画像を記事内に表示できるようにする

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -14,13 +14,13 @@ class Admin::ArticlesController < AdminController
 
   def edit; end
 
-  # やること
   def upload_image
     uploader = Uploader::GoogleDriveUploader.new(file: image_params)
-    upload_file = uploader.upload!(return_upload_file?: true)
+    upload_file = uploader.upload!(return_upload_file: true)
 
-    # TODO: 返却されたURLをフロントに返す
-    
+    respond_to do |format|
+      format.json { render json: upload_file.human_url }
+    end
   end
 
   def create

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -15,11 +15,12 @@ class Admin::ArticlesController < AdminController
   def edit; end
 
   # やること
-  # TODO: 返却されたURLをフロントに返す
-  # ここでやるのはパラメータの受け渡しとフロントへの返却ぐらいにする
   def upload_image
     uploader = Uploader::GoogleDriveUploader.new(file: image_params)
-    uploader.upload!
+    upload_file = uploader.upload!(return_upload_file?: true)
+
+    # TODO: 返却されたURLをフロントに返す
+    
   end
 
   def create

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -19,7 +19,7 @@ class Admin::ArticlesController < AdminController
     upload_file = uploader.upload!(return_upload_file: true)
 
     respond_to do |format|
-      format.json { render json: upload_file.human_url }
+      format.json { render json: { title: upload_file.title , id: upload_file.id } }
     end
   end
 

--- a/app/controllers/concerns/uploader/google_drive_uploader.rb
+++ b/app/controllers/concerns/uploader/google_drive_uploader.rb
@@ -22,7 +22,6 @@ module Uploader
       file_path = "#{Rails.root}/#{@file.original_filename}"
       folder.upload_from_file(file_path, @file.original_filename, convert: false)
 
-      # uploaded_file.human_urlで取得できる
       uploaded_file = session.file_by_title(@file.original_filename)
 
       file_delete file_path

--- a/app/controllers/concerns/uploader/google_drive_uploader.rb
+++ b/app/controllers/concerns/uploader/google_drive_uploader.rb
@@ -13,7 +13,7 @@ module Uploader
       @file = file
     end
 
-    def upload!
+    def upload!(return_upload_file?: false)
       file_open
 
       auth = get_auth_fetched_access_token!
@@ -22,7 +22,11 @@ module Uploader
       file_path = "#{Rails.root}/#{@file.original_filename}"
       folder.upload_from_file(file_path, @file.original_filename, convert: false)
 
+      # uploaded_file.human_urlで取得できる
+      uploaded_file = session.file_by_title(@file.original_filename)
+
       file_delete file_path
+      return uploaded_file if return_upload_file?
     end
 
     private

--- a/app/controllers/concerns/uploader/google_drive_uploader.rb
+++ b/app/controllers/concerns/uploader/google_drive_uploader.rb
@@ -13,7 +13,7 @@ module Uploader
       @file = file
     end
 
-    def upload!(return_upload_file?: false)
+    def upload!(return_upload_file: false)
       file_open
 
       auth = get_auth_fetched_access_token!
@@ -26,7 +26,7 @@ module Uploader
       uploaded_file = session.file_by_title(@file.original_filename)
 
       file_delete file_path
-      return uploaded_file if return_upload_file?
+      return uploaded_file if return_upload_file
     end
 
     private

--- a/app/webpack/packs/admin/articles/markdown.js
+++ b/app/webpack/packs/admin/articles/markdown.js
@@ -64,7 +64,6 @@ $(function () {
 
     axios.post(`${location.origin}/admin/articles/upload_image`, formData)
       .then(response => {
-        // response.data内に、"https://drive.google.com/file/d/1JQYr8ruFUdmWNFsSw7zCgckOgGJP1C0G/view?usp=drivesdk"のようなデータが入っている
         if (!response.data) returns
         const id = response.data.id
         const title = response.data.title

--- a/app/webpack/packs/admin/articles/markdown.js
+++ b/app/webpack/packs/admin/articles/markdown.js
@@ -22,6 +22,25 @@ const setAxiosHeader = () => {
   }
 }
 
+const replacedImageUrl = ({ title = '', id = '' }) => {
+  return `![${title}](https://drive.google.com/uc?export=view&id=${id})`
+}
+
+// insertedText: 挿入したいテキスト
+const insertImageUrlIntoTextarea = (insertedText) => {
+  const textarea = document.getElementById('article-text')
+  let sentence = textarea.value
+  let len = sentence.length
+  let pos = textarea.selectionStart
+
+  let before = sentence.substr(0, pos)
+  let after = sentence.substr(pos, len)
+  sentence = before + insertedText + after
+
+  // MEMO: textarea内の文章の置き換え
+  textarea.value = sentence
+}
+
 $(function () {
   // 遷移、ロード時に実行させる
   preview($('#article-text'));
@@ -44,10 +63,11 @@ $(function () {
     axios.post(`${location.origin}/admin/articles/upload_image`, formData)
       .then(response => {
         // response.data内に、"https://drive.google.com/file/d/1JQYr8ruFUdmWNFsSw7zCgckOgGJP1C0G/view?usp=drivesdk"のようなデータが入っている
-        // data内のURL書き換え
-        // 該当部分に要素追加
-        debugger
-        console.log(response)
+        if (!response.data) returns
+        const id = response.data.id
+        const title = response.data.title
+        const imageUrl = replacedImageUrl({ title: title, id: id })
+        insertImageUrlIntoTextarea(imageUrl)
       })
   });
 });

--- a/app/webpack/packs/admin/articles/markdown.js
+++ b/app/webpack/packs/admin/articles/markdown.js
@@ -17,7 +17,8 @@ const preview = function (sel) {
 const setAxiosHeader = () => {
   axios.defaults.headers.common = {
     'X-Requested-With': 'XMLHttpRequest',
-    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+    'Content-Type': 'application/json'
   }
 }
 
@@ -41,8 +42,12 @@ $(function () {
     setAxiosHeader()
 
     axios.post(`${location.origin}/admin/articles/upload_image`, formData)
-      .then(() => {
-        console.log('success')
+      .then(response => {
+        // response.data内に、"https://drive.google.com/file/d/1JQYr8ruFUdmWNFsSw7zCgckOgGJP1C0G/view?usp=drivesdk"のようなデータが入っている
+        // data内のURL書き換え
+        // 該当部分に要素追加
+        debugger
+        console.log(response)
       })
   });
 });

--- a/app/webpack/packs/admin/articles/markdown.js
+++ b/app/webpack/packs/admin/articles/markdown.js
@@ -13,6 +13,9 @@ const preview = function (sel) {
   $('#markdown-preview').html(html);
 }
 
+// テキストエリア内の内容をプレビュー画面に反映する
+const updatePreview = () => preview($('#article-text'))
+
 // csrf対策通過用にaxiosにheaderを設定する
 const setAxiosHeader = () => {
   axios.defaults.headers.common = {
@@ -47,8 +50,7 @@ $(function () {
 
   $('#article-text').on(
     "keyup", function () {
-      let sel = $(this)
-      preview(sel)
+      updatePreview()
     }
   );
 
@@ -68,6 +70,7 @@ $(function () {
         const title = response.data.title
         const imageUrl = replacedImageUrl({ title: title, id: id })
         insertImageUrlIntoTextarea(imageUrl)
+        updatePreview()
       })
   });
 });


### PR DESCRIPTION
## What

テキストエリア内に画像をドラッグ＆ドロップした際にGoogle Driveに画像をアップロードしつつ、バック→フロントに画像のID等の情報を渡すことで、テキストエリア内に画像表示用の文字列を生成して挿入できるようにした。
これにより表題の挙動を実現できるようになった。
